### PR TITLE
feat: add OpenAI-compatible prompt expander (MiniMax, OpenAI, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,39 @@ pip install "xfuser>=0.4.1"
 torchrun --nproc_per_node=8 generate.py --task s2v-1.3B --size 832*480 --ckpt_dir ./Wan2.1-T2V-1.3B --phantom_ckpt ./Phantom-Wan-Models/Phantom-Wan-1.3B.pth  --ref_image "examples/ref3.png,examples/ref4.png" --dit_fsdp --t5_fsdp --ulysses_size 4 --ring_size 2 --prompt "夕阳下，一位有着小麦色肌肤、留着乌黑长发的女人穿上有着大朵立体花朵装饰、肩袖处带有飘逸纱带的红色纱裙，漫步在金色的海滩上，海风轻拂她的长发，画面唯美动人。" --base_seed 42
 ```
 
-> 💡Note: 
+> 💡Note:
 > * Changing `--ref_image` can achieve single reference Subject-to-Video generation or multi-reference Subject-to-Video generation. The number of reference images should be within 4.
 > * To achieve the best generation results, we recommend that you describe the visual content of the reference image as accurately as possible when writing `--prompt`. For example, "examples/ref1.png" can be described as "a toy camera in yellow and red with blue buttons".
 > * When the generated video is unsatisfactory, the most straightforward solution is to try changing the `--base_seed` and modifying the description in the `--prompt`.
+
+### Prompt Extension with OpenAI-Compatible APIs (e.g. MiniMax)
+
+In addition to DashScope and local Qwen models, you can use any OpenAI-compatible LLM API for prompt extension. This is useful when you want to use cloud LLM providers like [MiniMax](https://www.minimax.io/) without the DashScope dependency.
+
+```sh
+# Install the openai package
+pip install openai
+
+# Set your API key
+export MINIMAX_API_KEY="your-api-key"
+
+# Use MiniMax (default) for prompt extension
+python generate.py --task s2v-1.3B --size 832*480 \
+    --ckpt_dir ./Wan2.1-T2V-1.3B \
+    --phantom_ckpt ./Phantom-Wan-Models/Phantom-Wan-1.3B.pth \
+    --ref_image "examples/ref1.png,examples/ref2.png" \
+    --prompt "A girl playing with a dog on a sunny meadow" \
+    --use_prompt_extend --prompt_extend_method openai_compatible
+
+# Use a different model or provider
+export OPENAI_BASE_URL="https://api.openai.com/v1"
+export OPENAI_API_KEY="your-openai-key"
+python generate.py --task t2v-14B --size 1280*720 \
+    --ckpt_dir ./Wan2.1-T2V-14B \
+    --prompt "A cat surfing on the ocean" \
+    --use_prompt_extend --prompt_extend_method openai_compatible \
+    --prompt_extend_model gpt-4o
+```
 
 For more inference examples, please refer to "infer.sh". You will get the following generated results:
 

--- a/generate.py
+++ b/generate.py
@@ -27,7 +27,7 @@ from PIL import Image, ImageOps
 
 import phantom_wan
 from phantom_wan.configs import WAN_CONFIGS, SIZE_CONFIGS, MAX_AREA_CONFIGS, SUPPORTED_SIZES
-from phantom_wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
+from phantom_wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander, OpenAICompatPromptExpander
 from phantom_wan.utils.utils import cache_video, cache_image, str2bool
 
 EXAMPLE_PROMPT = {
@@ -169,8 +169,8 @@ def _parse_args():
         "--prompt_extend_method",
         type=str,
         default="local_qwen",
-        choices=["dashscope", "local_qwen"],
-        help="The prompt extend method to use.")
+        choices=["dashscope", "local_qwen", "openai_compatible"],
+        help="The prompt extend method to use. 'openai_compatible' works with any OpenAI-compatible API (e.g. MiniMax).")
     parser.add_argument(
         "--prompt_extend_model",
         type=str,
@@ -326,6 +326,10 @@ def generate(args):
                 model_name=args.prompt_extend_model,
                 is_vl="i2v" in args.task,
                 device=rank)
+        elif args.prompt_extend_method == "openai_compatible":
+            prompt_expander = OpenAICompatPromptExpander(
+                model_name=args.prompt_extend_model,
+                is_vl="i2v" in args.task)
         else:
             raise NotImplementedError(
                 f"Unsupport prompt_extend_method: {args.prompt_extend_method}")

--- a/phantom_wan/utils/prompt_extend.py
+++ b/phantom_wan/utils/prompt_extend.py
@@ -297,6 +297,186 @@ class DashScopePromptExpander(PromptExpander):
                 response, ensure_ascii=False))
 
 
+class OpenAICompatPromptExpander(PromptExpander):
+    """Prompt expander using any OpenAI-compatible API (e.g. MiniMax, OpenAI).
+
+    This expander calls a cloud LLM via the OpenAI Python SDK, making it
+    compatible with any provider that exposes the ``/v1/chat/completions``
+    endpoint.  By default it points at the **MiniMax** API
+    (``https://api.minimax.io/v1``) with the ``MiniMax-M2.7`` model.
+
+    Environment variables
+    ---------------------
+    ``OPENAI_API_KEY`` / ``MINIMAX_API_KEY``
+        API key used for authentication.  ``MINIMAX_API_KEY`` is checked first.
+    ``OPENAI_BASE_URL``
+        Override the base URL when using a provider other than MiniMax.
+    """
+
+    # Default to MiniMax
+    DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+    DEFAULT_MODEL = "MiniMax-M2.7"
+
+    def __init__(
+        self,
+        api_key=None,
+        model_name=None,
+        base_url=None,
+        max_image_size=512 * 512,
+        retry_times=4,
+        is_vl=False,
+        **kwargs,
+    ):
+        if model_name is None:
+            model_name = self.DEFAULT_MODEL
+        super().__init__(model_name, is_vl, **kwargs)
+
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise ImportError(
+                "The 'openai' package is required for OpenAICompatPromptExpander. "
+                "Install it with: pip install openai"
+            )
+
+        if api_key is None:
+            api_key = os.environ.get("MINIMAX_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
+        if not api_key:
+            raise ValueError(
+                "An API key is required. Set MINIMAX_API_KEY or OPENAI_API_KEY, "
+                "or pass api_key directly."
+            )
+
+        if base_url is None:
+            base_url = os.environ.get("OPENAI_BASE_URL", self.DEFAULT_BASE_URL)
+
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.model = model_name
+        self.max_image_size = max_image_size
+        self.retry_times = retry_times
+
+    def _strip_think_tags(self, text):
+        """Remove <think>...</think> blocks that some models emit."""
+        import re
+        return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+
+    def extend(self, prompt, system_prompt, seed=-1, *args, **kwargs):
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        exception = None
+        for _ in range(self.retry_times):
+            try:
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    temperature=0.7,
+                )
+                expanded = self._strip_think_tags(
+                    response.choices[0].message.content
+                )
+                return PromptOutput(
+                    status=True,
+                    prompt=expanded,
+                    seed=seed,
+                    system_prompt=system_prompt,
+                    message=json.dumps(
+                        {"model": self.model, "content": expanded},
+                        ensure_ascii=False,
+                    ),
+                )
+            except Exception as e:
+                exception = e
+        return PromptOutput(
+            status=False,
+            prompt=prompt,
+            seed=seed,
+            system_prompt=system_prompt,
+            message=str(exception),
+        )
+
+    def extend_with_img(
+        self,
+        prompt,
+        system_prompt,
+        image: Union[Image.Image, str] = None,
+        seed=-1,
+        *args,
+        **kwargs,
+    ):
+        import base64
+
+        if isinstance(image, str):
+            image = Image.open(image).convert("RGB")
+
+        # Resize to respect max_image_size
+        w, h = image.width, image.height
+        area = min(w * h, self.max_image_size)
+        aspect_ratio = h / w
+        resized_h = round(math.sqrt(area * aspect_ratio))
+        resized_w = round(math.sqrt(area / aspect_ratio))
+        image = image.resize((resized_w, resized_h))
+
+        # Encode image to base64 data URL
+        import io
+
+        buf = io.BytesIO()
+        image.save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        image_url = f"data:image/png;base64,{b64}"
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image_url},
+                    },
+                ],
+            },
+        ]
+
+        exception = None
+        status = False
+        result_prompt = prompt
+        for _ in range(self.retry_times):
+            try:
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    temperature=0.7,
+                )
+                result_prompt = self._strip_think_tags(
+                    response.choices[0].message.content
+                )
+                status = True
+                break
+            except Exception as e:
+                exception = e
+
+        result_prompt = result_prompt.replace("\n", "\\n")
+        return PromptOutput(
+            status=status,
+            prompt=result_prompt,
+            seed=seed,
+            system_prompt=system_prompt,
+            message=(
+                str(exception)
+                if not status
+                else json.dumps(
+                    {"model": self.model, "content": result_prompt},
+                    ensure_ascii=False,
+                )
+            ),
+        )
+
+
 class QwenPromptExpander(PromptExpander):
     model_dict = {
         "QwenVL2.5_3B": "Qwen/Qwen2.5-VL-3B-Instruct",

--- a/tests/test_openai_compat_integration.py
+++ b/tests/test_openai_compat_integration.py
@@ -1,0 +1,63 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+"""Integration tests for OpenAICompatPromptExpander with MiniMax API.
+
+These tests require a live MINIMAX_API_KEY and network access.
+Skip automatically when the key is not set.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Stub heavy dependencies to avoid needing torch etc.
+for mod_name in ("dashscope", "torch"):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+_PE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "phantom_wan", "utils", "prompt_extend.py"
+)
+_spec = importlib.util.spec_from_file_location("prompt_extend", _PE_PATH)
+prompt_extend = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prompt_extend)
+
+OpenAICompatPromptExpander = prompt_extend.OpenAICompatPromptExpander
+PromptOutput = prompt_extend.PromptOutput
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+SKIP_REASON = "MINIMAX_API_KEY not set"
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, SKIP_REASON)
+class TestOpenAICompatIntegration(unittest.TestCase):
+    """Live integration tests against MiniMax API."""
+
+    def setUp(self):
+        self.expander = OpenAICompatPromptExpander(
+            model_name="MiniMax-M2.7",
+            retry_times=2,
+        )
+
+    def test_extend_english_prompt(self):
+        result = self.expander("A cat sitting on a surfboard", tar_lang="en")
+        self.assertTrue(result.status, f"API call failed: {result.message}")
+        self.assertGreater(len(result.prompt), 20)
+
+    def test_extend_chinese_prompt(self):
+        result = self.expander("一只猫坐在冲浪板上", tar_lang="ch")
+        self.assertTrue(result.status, f"API call failed: {result.message}")
+        self.assertGreater(len(result.prompt), 10)
+
+    def test_extend_returns_prompt_output(self):
+        result = self.expander("sunset on the beach", tar_lang="en")
+        self.assertIsInstance(result, PromptOutput)
+        self.assertTrue(result.status)
+        self.assertIsInstance(result.prompt, str)
+        self.assertIsInstance(result.seed, int)
+        self.assertIsInstance(result.message, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_compat_prompt_expander.py
+++ b/tests/test_openai_compat_prompt_expander.py
@@ -1,0 +1,308 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+"""Unit tests for OpenAICompatPromptExpander."""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Load prompt_extend module directly to avoid phantom_wan/__init__.py imports
+# ---------------------------------------------------------------------------
+
+# Stub only the direct dependencies of prompt_extend.py
+for mod_name in ("dashscope", "torch"):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+_PE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "phantom_wan", "utils", "prompt_extend.py"
+)
+_spec = importlib.util.spec_from_file_location("prompt_extend", _PE_PATH)
+prompt_extend = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prompt_extend)
+
+OpenAICompatPromptExpander = prompt_extend.OpenAICompatPromptExpander
+PromptOutput = prompt_extend.PromptOutput
+LM_CH_SYS_PROMPT = prompt_extend.LM_CH_SYS_PROMPT
+LM_EN_SYS_PROMPT = prompt_extend.LM_EN_SYS_PROMPT
+VL_CH_SYS_PROMPT = prompt_extend.VL_CH_SYS_PROMPT
+VL_EN_SYS_PROMPT = prompt_extend.VL_EN_SYS_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(content="expanded prompt"):
+    """Build a fake openai chat completion response."""
+    choice = MagicMock()
+    choice.message.content = content
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _make_expander(is_vl=False, model_name=None, base_url=None):
+    """Create an expander with a mocked OpenAI client."""
+    with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+        with patch("openai.OpenAI") as MockClient:
+            instance = MockClient.return_value
+            instance.chat = MagicMock()
+            instance.chat.completions = MagicMock()
+            exp = OpenAICompatPromptExpander(
+                model_name=model_name,
+                base_url=base_url,
+                is_vl=is_vl,
+            )
+            return exp, instance
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOpenAICompatPromptExpanderInit(unittest.TestCase):
+    """Test initialization and configuration."""
+
+    def test_default_model_and_url(self):
+        exp, _ = _make_expander()
+        self.assertEqual(exp.model, "MiniMax-M2.7")
+
+    def test_custom_model_name(self):
+        exp, _ = _make_expander(model_name="gpt-4o")
+        self.assertEqual(exp.model, "gpt-4o")
+
+    def test_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            for key in ("MINIMAX_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"):
+                os.environ.pop(key, None)
+            with self.assertRaises(ValueError):
+                with patch("openai.OpenAI"):
+                    OpenAICompatPromptExpander()
+
+    def test_minimax_api_key_env(self):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "mm-key"}, clear=True):
+            os.environ.pop("OPENAI_API_KEY", None)
+            with patch("openai.OpenAI"):
+                exp = OpenAICompatPromptExpander()
+                self.assertIsNotNone(exp.client)
+
+    def test_openai_api_key_fallback(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "oai-key"}, clear=True):
+            os.environ.pop("MINIMAX_API_KEY", None)
+            with patch("openai.OpenAI"):
+                exp = OpenAICompatPromptExpander()
+                self.assertIsNotNone(exp.client)
+
+    def test_is_vl_flag(self):
+        exp, _ = _make_expander(is_vl=True)
+        self.assertTrue(exp.is_vl)
+
+    def test_retry_times_default(self):
+        exp, _ = _make_expander()
+        self.assertEqual(exp.retry_times, 4)
+
+
+class TestStripThinkTags(unittest.TestCase):
+    """Test the _strip_think_tags helper."""
+
+    def setUp(self):
+        self.exp, _ = _make_expander()
+
+    def test_no_think_tags(self):
+        self.assertEqual(self.exp._strip_think_tags("hello world"), "hello world")
+
+    def test_single_think_block(self):
+        text = "<think>some reasoning</think>the answer"
+        self.assertEqual(self.exp._strip_think_tags(text), "the answer")
+
+    def test_multiline_think_block(self):
+        text = "<think>\nline1\nline2\n</think>\nresult"
+        self.assertEqual(self.exp._strip_think_tags(text), "result")
+
+    def test_multiple_think_blocks(self):
+        text = "<think>a</think>middle<think>b</think>end"
+        self.assertEqual(self.exp._strip_think_tags(text), "middleend")
+
+
+class TestExtend(unittest.TestCase):
+    """Test text-only prompt extension."""
+
+    def test_successful_extend(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response(
+            "expanded prompt"
+        )
+        result = exp("test prompt", tar_lang="en")
+        self.assertIsInstance(result, PromptOutput)
+        self.assertTrue(result.status)
+        self.assertEqual(result.prompt, "expanded prompt")
+
+    def test_extend_chinese(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response(
+            "扩展后的提示词"
+        )
+        result = exp("测试提示词", tar_lang="ch")
+        self.assertTrue(result.status)
+        self.assertEqual(result.prompt, "扩展后的提示词")
+
+    def test_extend_strips_think_tags(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response(
+            "<think>reasoning</think>clean prompt"
+        )
+        result = exp("test", tar_lang="en")
+        self.assertTrue(result.status)
+        self.assertEqual(result.prompt, "clean prompt")
+
+    def test_extend_failure_returns_original(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.side_effect = RuntimeError("API error")
+        exp.retry_times = 2
+        result = exp("original prompt", tar_lang="en")
+        self.assertFalse(result.status)
+        self.assertEqual(result.prompt, "original prompt")
+        self.assertIn("API error", result.message)
+
+    def test_extend_retries_on_failure(self):
+        exp, client = _make_expander()
+        exp.retry_times = 3
+        client.chat.completions.create.side_effect = [
+            RuntimeError("fail1"),
+            RuntimeError("fail2"),
+            _make_mock_response("success"),
+        ]
+        result = exp("test", tar_lang="en")
+        self.assertTrue(result.status)
+        self.assertEqual(result.prompt, "success")
+        self.assertEqual(client.chat.completions.create.call_count, 3)
+
+    def test_extend_uses_correct_system_prompt_en(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response("ok")
+        exp("test", tar_lang="en")
+        call_args = client.chat.completions.create.call_args
+        messages = call_args.kwargs.get("messages", call_args[1].get("messages"))
+        self.assertEqual(messages[0]["content"], LM_EN_SYS_PROMPT)
+
+    def test_extend_uses_correct_system_prompt_ch(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response("ok")
+        exp("test", tar_lang="ch")
+        call_args = client.chat.completions.create.call_args
+        messages = call_args.kwargs.get("messages", call_args[1].get("messages"))
+        self.assertEqual(messages[0]["content"], LM_CH_SYS_PROMPT)
+
+    def test_extend_uses_model_name(self):
+        exp, client = _make_expander(model_name="MiniMax-M2.5")
+        client.chat.completions.create.return_value = _make_mock_response("ok")
+        exp("test", tar_lang="en")
+        call_args = client.chat.completions.create.call_args
+        model = call_args.kwargs.get("model", call_args[1].get("model"))
+        self.assertEqual(model, "MiniMax-M2.5")
+
+    def test_extend_message_contains_json(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response("out")
+        result = exp("test", tar_lang="en")
+        msg = json.loads(result.message)
+        self.assertEqual(msg["content"], "out")
+        self.assertEqual(msg["model"], "MiniMax-M2.7")
+
+    def test_extend_sets_temperature(self):
+        exp, client = _make_expander()
+        client.chat.completions.create.return_value = _make_mock_response("ok")
+        exp("test", tar_lang="en")
+        call_args = client.chat.completions.create.call_args
+        self.assertEqual(call_args.kwargs.get("temperature"), 0.7)
+
+
+class TestExtendWithImg(unittest.TestCase):
+    """Test image+text prompt extension."""
+
+    def _make_test_image(self):
+        import io
+        img = MagicMock()
+        img.width = 100
+        img.height = 100
+        img.convert.return_value = img
+
+        def resize_fn(size):
+            resized = MagicMock()
+            resized.width = size[0]
+            resized.height = size[1]
+            buf_content = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
+            resized.save = MagicMock(
+                side_effect=lambda b, format: b.write(buf_content)
+            )
+            return resized
+        img.resize = resize_fn
+        return img
+
+    def test_extend_with_img_success(self):
+        exp, client = _make_expander(is_vl=True)
+        client.chat.completions.create.return_value = _make_mock_response(
+            "image-based expansion"
+        )
+        result = exp("describe this", tar_lang="en", image=self._make_test_image())
+        self.assertTrue(result.status)
+        self.assertIn("image-based expansion", result.prompt)
+
+    def test_extend_with_img_sends_base64(self):
+        exp, client = _make_expander(is_vl=True)
+        client.chat.completions.create.return_value = _make_mock_response("ok")
+        exp("test", tar_lang="en", image=self._make_test_image())
+        call_args = client.chat.completions.create.call_args
+        messages = call_args.kwargs.get("messages", call_args[1].get("messages"))
+        user_content = messages[1]["content"]
+        self.assertIsInstance(user_content, list)
+        self.assertEqual(len(user_content), 2)
+        self.assertEqual(user_content[0]["type"], "text")
+        self.assertEqual(user_content[1]["type"], "image_url")
+        self.assertTrue(
+            user_content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+        )
+
+    def test_extend_with_img_failure(self):
+        exp, client = _make_expander(is_vl=True)
+        client.chat.completions.create.side_effect = RuntimeError("VL error")
+        exp.retry_times = 1
+        result = exp("test", tar_lang="en", image=self._make_test_image())
+        self.assertFalse(result.status)
+        self.assertIn("VL error", result.message)
+
+    def test_extend_with_img_uses_vl_system_prompt(self):
+        exp, client = _make_expander(is_vl=True)
+        client.chat.completions.create.return_value = _make_mock_response("ok")
+        exp("test", tar_lang="ch", image=self._make_test_image())
+        call_args = client.chat.completions.create.call_args
+        messages = call_args.kwargs.get("messages", call_args[1].get("messages"))
+        self.assertEqual(messages[0]["content"], VL_CH_SYS_PROMPT)
+
+
+class TestDecideSystemPrompt(unittest.TestCase):
+    """Test system prompt selection logic."""
+
+    def test_lm_ch(self):
+        exp, _ = _make_expander(is_vl=False)
+        self.assertEqual(exp.decide_system_prompt("ch"), LM_CH_SYS_PROMPT)
+
+    def test_lm_en(self):
+        exp, _ = _make_expander(is_vl=False)
+        self.assertEqual(exp.decide_system_prompt("en"), LM_EN_SYS_PROMPT)
+
+    def test_vl_ch(self):
+        exp, _ = _make_expander(is_vl=True)
+        self.assertEqual(exp.decide_system_prompt("ch"), VL_CH_SYS_PROMPT)
+
+    def test_vl_en(self):
+        exp, _ = _make_expander(is_vl=True)
+        self.assertEqual(exp.decide_system_prompt("en"), VL_EN_SYS_PROMPT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a third prompt extension backend (`OpenAICompatPromptExpander`) that works with any **OpenAI-compatible LLM API**, complementing the existing DashScope and local Qwen backends.

- By default uses **MiniMax** (`MiniMax-M2.7` at `https://api.minimax.io/v1`), but the base URL and model can be overridden for **OpenAI**, **DeepSeek**, or any other OpenAI-compatible provider
- Supports both text-only (`extend`) and image+text (`extend_with_img`) prompt extension via base64 encoding
- Includes think-tag stripping for reasoning models and configurable retries
- New `--prompt_extend_method openai_compatible` CLI option in `generate.py`

### Changes

| File | Description |
|------|-------------|
| `phantom_wan/utils/prompt_extend.py` | New `OpenAICompatPromptExpander` class |
| `generate.py` | Wire up `openai_compatible` method + import |
| `README.md` | Usage docs for MiniMax/OpenAI-compatible prompt extension |
| `tests/test_openai_compat_prompt_expander.py` | 29 unit tests |
| `tests/test_openai_compat_integration.py` | 3 live integration tests |

### Usage

```bash
export MINIMAX_API_KEY="your-key"
python generate.py --task s2v-1.3B --size 832*480 \
  --ckpt_dir ./Wan2.1-T2V-1.3B \
  --phantom_ckpt ./Phantom-Wan-Models/Phantom-Wan-1.3B.pth \
  --ref_image "examples/ref1.png,examples/ref2.png" \
  --prompt "A girl playing with a dog" \
  --use_prompt_extend --prompt_extend_method openai_compatible
```

## Test plan

- [x] 29 unit tests pass (mocked OpenAI client)
- [x] 3 integration tests pass (live MiniMax API)
- [x] Existing DashScope/Qwen codepaths unaffected (no changes to existing classes)
